### PR TITLE
Update AwaitableHTTPRequest.gd

### DIFF
--- a/AwaitableHTTPRequest.gd
+++ b/AwaitableHTTPRequest.gd
@@ -50,6 +50,8 @@ class HTTPResult extends RefCounted:
 ##@export var http: AwaitableHTTPRequest
 ##
 ##func _ready() -> void:
+##        http = AwaitableHTTPRequest.new()
+##        add_child(http)
 ##    var r := await http.async_request('https://api.github.com/users/swarkin')
 ##
 ##    if r.success:
@@ -57,7 +59,7 @@ class HTTPResult extends RefCounted:
 ##        print(r.headers['Content-Type'])  # application/json
 ##        print(r.json['bio'])              # fox.
 ##[/codeblock]
-func async_request(url: String, method := HTTPClient.Method.METHOD_GET, custom_headers := PackedStringArray(), request_body := '') -> HTTPResult:
+func async_request(url: String, custom_headers := PackedStringArray(), method := HTTPClient.Method.METHOD_GET, request_body := '') -> HTTPResult:
 	is_requesting = true
 
 	var e := request(url, custom_headers, method, request_body)

--- a/AwaitableHTTPRequest.gd
+++ b/AwaitableHTTPRequest.gd
@@ -50,8 +50,8 @@ class HTTPResult extends RefCounted:
 ##@export var http: AwaitableHTTPRequest
 ##
 ##func _ready() -> void:
-##        http = AwaitableHTTPRequest.new()
-##        add_child(http)
+##    http = AwaitableHTTPRequest.new()
+##    add_child(http)
 ##    var r := await http.async_request('https://api.github.com/users/swarkin')
 ##
 ##    if r.success:


### PR DESCRIPTION
Address issue https://github.com/Swarkin/Godot-AwaitableHTTPRequest/issues/3 by reordering arguments in `async_request()` function so it matches those of HTTPRequest 
Address issue https://github.com/Swarkin/Godot-AwaitableHTTPRequest/issues/4 by changing provided example, hinting more explicitly that there must be a node of AwaitableHTTPRequest class and make the example work out of the box